### PR TITLE
Adjust mod_PROB_func to conform to the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - **NEW**: crow ops
 - **NEW**: `TI.PRM.CALIB` alias added (was already in the docs)
 - **FIX**: `SCENE` would crash if parameter was out of bounds
+- **FIX**: `PROB 100` would only execute 99.01% of the time.
 
 ## v3.2.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -41,6 +41,7 @@
 - **NEW**: crow ops
 - **NEW**: `TI.PRM.CALIB` alias added (was already in the docs)
 - **FIX**: `SCENE` would crash if parameter was out of bounds
+- **FIX**: `PROB 100` would execute only 99.01% of the time.
 
 ## v3.2.0
 

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -86,7 +86,7 @@ static void mod_PROB_func(scene_state_t *ss, exec_state_t *es,
     int16_t a = cs_pop(cs);
     random_state_t *r = &ss->rand_states.s.prob.rand;
 
-    if (random_next(r) % 101 < a) { process_command(ss, es, post_command); }
+    if (random_next(r) % 100 < a) { process_command(ss, es, post_command); }
 }
 
 static void mod_IF_func(scene_state_t *ss, exec_state_t *es,

--- a/tests/process_tests.c
+++ b/tests/process_tests.c
@@ -83,6 +83,13 @@ TEST test_ADD() {
     PASS();
 }
 
+TEST test_PROB() {
+    char* test1[3] = { "X 0", "PROB 100: X + X 1", "X" };
+    for (int i = 0; i < 1000; i++) { CHECK_CALL(process_helper(3, test1, 1)); }
+
+    PASS();
+}
+
 TEST test_IF() {
     char* test1[3] = { "X 0", "IF 1: X 1", "X" };
     CHECK_CALL(process_helper(3, test1, 1));
@@ -300,6 +307,7 @@ TEST test_blank_command() {
 SUITE(process_suite) {
     RUN_TEST(test_numbers);
     RUN_TEST(test_ADD);
+    RUN_TEST(test_PROB);
     RUN_TEST(test_IF);
     RUN_TEST(test_FLIP);
     RUN_TEST(test_L);


### PR DESCRIPTION
#### What does this PR do?

The docs for PROB say "potentially execute command with probability `x` (0-100)"
The current behaviour is that x maps to a probability of x/101. x = 100 executes with the probability of 99.01%
This adjusts the behaviour so that x maps to a probability of x%.

I added a test for PROB 100, but anything probability related is messy to test, so feel free to reject that part.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

I found a random youtube comment mentioning this, but I did find a mention on lines:
https://llllllll.co/t/teletype-workflow-basics-and-questions/12392/640

#### How should this be manually tested?

#1
X 0
L 1 10000: $ 2

#2
PROB 100: X + X 1

After running script 1, X should be 10,000. It is ~9900 each time.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation 
  * Documentation was correct.
* [ ] updated `help_mode.c` (if applicable)
  * No change required.
* [x] run `make format` on each commit
* [x] run tests
